### PR TITLE
Fix `rm -rf` for OS X

### DIFF
--- a/do.rb
+++ b/do.rb
@@ -37,7 +37,7 @@ Dir.entries('test').each do |path|
 		end
 	end
 	`echo '"_":null},' >> data.json`
-	`rm ./#{repo} -rf`
+	`rm -rf ./#{repo}`
 	`rm ./aheui` if (File.exist?("./aheui") || File.symlink?("./aheui"))
 	`rm ./aheui.pre.sh` if has_pre_script
 	`rm ./aheui.post.sh` if has_post_script


### PR DESCRIPTION
``` sh
rm: -rf: No such file or directory
```
